### PR TITLE
feat: 兼容mac新版本微信开发者工具

### DIFF
--- a/weChatCli.js
+++ b/weChatCli.js
@@ -73,7 +73,7 @@ class WeChatCli {
           wxPaths = [path.join(stdout, '/Contents/Resources/app.nw/bin/cli')];
         }
         // defaults read
-        wxPaths.push('/Applications/wechatwebdevtools.app/Contents/Resources/app.nw/bin/cli');
+        wxPaths.push('/Applications/wechatwebdevtools.app/Contents/Resources/app.nw/bin/cli', '/Applications/wechatwebdevtools.app/Contents/MacOS/cli');
         break;
       case 'win32':
         // defaults read
@@ -105,7 +105,7 @@ class WeChatCli {
 
           return true;
         } else {
-          console.error('open error!',);
+          console.error('open error!');
           console.error(result.stderr);
           return false;
         }


### PR DESCRIPTION
Mac(macOS Catalina
版本10.15.4)端更新为最新的微信开发者工具之后mini-deploy无法打开微信开发者工具(Stable v1.02.2004020)